### PR TITLE
One conversion for all playlists

### DIFF
--- a/src/NPlaylist/Asx/AsxItem.cs
+++ b/src/NPlaylist/Asx/AsxItem.cs
@@ -13,14 +13,9 @@ namespace NPlaylist.Asx
         {
         }
 
-        public AsxItem(IPlaylistItem item) : base(path: item.Path)
+        public AsxItem(IPlaylistItem item) : base(item)
         {
-            foreach (var itemTags in item.Tags)
-            {
-                Tags[itemTags.Key] = itemTags.Value;
-            }
         }
-
         public string Title
         {
             get => Tags.TryGetValue(TagNames.Title, out var value) ? value : null;

--- a/src/NPlaylist/Asx/AsxPlaylist.cs
+++ b/src/NPlaylist/Asx/AsxPlaylist.cs
@@ -12,17 +12,8 @@ namespace NPlaylist.Asx
         {
         }
 
-        public AsxPlaylist(IPlaylist playlist)
+        public AsxPlaylist(IPlaylist playlist) : base(playlist)
         {
-            foreach (var playlistTag in playlist.Tags)
-            {
-                Tags[playlistTag.Key] = playlistTag.Value;
-            }
-
-            foreach (var playlistItem in playlist.GetItems())
-            {
-                Add(new AsxItem(playlistItem));
-            }
         }
 
         public string Title
@@ -35,6 +26,11 @@ namespace NPlaylist.Asx
         {
             get => Tags.TryGetValue(TagNames.Version, out var value) ? value : null;
             set => Tags[TagNames.Version] = value;
+        }
+
+        protected override AsxItem CreateItem(IPlaylistItem item) 
+        {
+            return new AsxItem(item);
         }
     }
 }

--- a/src/NPlaylist/BasePlaylist.cs
+++ b/src/NPlaylist/BasePlaylist.cs
@@ -14,6 +14,19 @@ namespace NPlaylist
             _items = new List<T>();
         }
 
+        protected BasePlaylist(IPlaylist playlist) : this()
+        {
+            foreach (var playlistTag in playlist.Tags)
+            {
+                Tags[playlistTag.Key] = playlistTag.Value;
+            }
+
+            foreach (var item in playlist.GetItems())
+            {
+               Add(CreateItem(item));
+            }
+        }
+
         public IDictionary<string, string> Tags { get; }
 
         public IEnumerable<T> Items => _items;
@@ -32,5 +45,7 @@ namespace NPlaylist
         {
             _items.Remove(item);
         }
+
+        protected abstract T CreateItem(IPlaylistItem item);
     }
 }

--- a/src/NPlaylist/BasePlaylistItem.cs
+++ b/src/NPlaylist/BasePlaylistItem.cs
@@ -17,5 +17,13 @@ namespace NPlaylist
             Tags = new Dictionary<string, string>();
             Path = path;
         }
+
+        protected BasePlaylistItem(IPlaylistItem item) : this(item.Path)
+        {
+            foreach (var itemTag in item.Tags)
+            {
+                Tags[itemTag.Key] = itemTag.Value;
+            }
+        }
     }
 }

--- a/src/NPlaylist/M3u/M3uItem.cs
+++ b/src/NPlaylist/M3u/M3uItem.cs
@@ -11,6 +11,10 @@ namespace NPlaylist.M3u
             Duration = duration;
         }
 
+        public M3uItem(IPlaylistItem item) : base(item)
+        {
+        }
+
         public decimal Duration
         {
             get

--- a/src/NPlaylist/M3u/M3uPlaylist.cs
+++ b/src/NPlaylist/M3u/M3uPlaylist.cs
@@ -2,5 +2,9 @@ namespace NPlaylist.M3u
 {
     public class M3uPlaylist : BasePlaylist<M3uItem>
     {
+        protected override M3uItem CreateItem(IPlaylistItem item)
+        {
+            return new M3uItem(item);
+        }
     }
 }

--- a/src/NPlaylist/Pls/PlsPlaylist.cs
+++ b/src/NPlaylist/Pls/PlsPlaylist.cs
@@ -11,5 +11,10 @@ namespace NPlaylist.Pls
         public PlsPlaylist()
         {
         }
+
+        protected override PlsPlaylistItem CreateItem(IPlaylistItem item)
+        {
+            return new PlsPlaylistItem(item);
+        }
     }
 }

--- a/src/NPlaylist/Pls/PlsPlaylistItem.cs
+++ b/src/NPlaylist/Pls/PlsPlaylistItem.cs
@@ -15,5 +15,9 @@ namespace NPlaylist.Pls
         public PlsPlaylistItem(string path) : base(path)
         {
         }
+
+        public PlsPlaylistItem(IPlaylistItem item) : base(item.Path)
+        {
+        }
     }
 }

--- a/src/NPlaylist/Wpl/WplItem.cs
+++ b/src/NPlaylist/Wpl/WplItem.cs
@@ -11,5 +11,9 @@ namespace NPlaylist.Wpl
             get => Tags.TryGetValue(TagNames.TrackId, out var value) ? value : null;
             set => Tags[TagNames.TrackId] = value;
         }
+
+        public WplItem(IPlaylistItem item) : base(item)
+        {
+        }
     }
 }

--- a/src/NPlaylist/Wpl/WplPlaylist.cs
+++ b/src/NPlaylist/Wpl/WplPlaylist.cs
@@ -19,5 +19,10 @@ namespace NPlaylist.Wpl
             get => Tags.TryGetValue(TagNames.Author, out var value) ? value : null;
             set => Tags[TagNames.Author] = value;
         }
+
+        protected override WplItem CreateItem(IPlaylistItem item)
+        {
+            return new WplItem(item);
+        }
     }
 }

--- a/src/NPlaylist/Xspf/XspfPlaylist.cs
+++ b/src/NPlaylist/Xspf/XspfPlaylist.cs
@@ -15,17 +15,13 @@ namespace NPlaylist.Xspf
         {
         }
 
-        public XspfPlaylist(IPlaylist playlist)
+        public XspfPlaylist(IPlaylist playlist) : base(playlist)
         {
-            foreach (var playlistTag in playlist.Tags)
-            {
-                Tags[playlistTag.Key] = playlistTag.Value;
-            }
+        }
 
-            foreach (var item in playlist.GetItems())
-            {
-                Add(new XspfPlaylistItem(item));
-            }
+        protected override XspfPlaylistItem CreateItem(IPlaylistItem item)
+        {
+            return new XspfPlaylistItem(item);
         }
     }
 }

--- a/src/NPlaylist/Xspf/XspfPlaylistItem.cs
+++ b/src/NPlaylist/Xspf/XspfPlaylistItem.cs
@@ -14,12 +14,8 @@ namespace NPlaylist.Xspf
         {
         }
 
-        public XspfPlaylistItem(IPlaylistItem item) : base(item.Path)
+        public XspfPlaylistItem(IPlaylistItem item) : base(item)
         {
-            foreach (var itemTag in item.Tags)
-            {
-                Tags[itemTag.Key] = itemTag.Value;
-            }
         }
     }
 }

--- a/tests/NPlaylist.Tests/BasePlaylistTests.cs
+++ b/tests/NPlaylist.Tests/BasePlaylistTests.cs
@@ -7,33 +7,30 @@ namespace NPlaylist.Tests
 {
     public class BasePlaylistTests
     {
+        private readonly BasePlaylist<IPlaylistItem> playlist;
+        private readonly IPlaylistItem dummyItem;
+
+        public BasePlaylistTests()
+        {
+            playlist = Substitute.For < BasePlaylist<IPlaylistItem>>();
+            dummyItem = Substitute.For<IPlaylistItem>();
+        }
         [Fact]
         public void Add_Adds_ExpectedItem()
         {
-            // Arrange 
-            var dummyItem = Substitute.For<IPlaylistItem>();
-            var basePlaylist = Substitute.For<BasePlaylist<IPlaylistItem>>();
+            playlist.Add(dummyItem);
 
-            // Act 
-            basePlaylist.Add(dummyItem);
-
-            // Assert 
-            Assert.Contains(dummyItem, basePlaylist.GetItems());
+            Assert.Contains(dummyItem, playlist.GetItems());
         }
 
         [Fact]
         public void Remove_Removes_ExpectedItem()
         {
-            // Arrange 
-            var dummyItem = Substitute.For<IPlaylistItem>();
-            var basePlaylist = Substitute.For<BasePlaylist<IPlaylistItem>>();
-            basePlaylist.Add(dummyItem);
+            playlist.Add(dummyItem);
 
-            // Act 
-            basePlaylist.Remove(dummyItem);
+            playlist.Remove(dummyItem);
 
-            // Assert 
-            Assert.DoesNotContain(dummyItem, basePlaylist.GetItems());
+            Assert.DoesNotContain(dummyItem, playlist.GetItems());
         }
     }
 }

--- a/tests/NPlaylist.Tests/XspfTests/XspfConversionTest.cs
+++ b/tests/NPlaylist.Tests/XspfTests/XspfConversionTest.cs
@@ -76,15 +76,15 @@ namespace NPlaylist.Tests.XspfTests
         {
             var playlist = Substitute.For<IPlaylist>();
             var item = Substitute.For<IPlaylistItem>();
-            var dictionary = new Dictionary<string,string>();
-            dictionary.Add(TagNames.TrackId,"testID");
-            item.Tags.Returns(dictionary);
+            var tags = new Dictionary<string,string>();
+            tags.Add("foo","testID");
+            item.Tags.Returns(tags);
             playlist.GetItems().Returns(new[] { item });
 
             var xspf = new XspfPlaylist(playlist);
 
-            var result = xspf.GetItems().First().Tags[TagNames.TrackId];
-            Assert.True(result.Equals("testID"));
+            var result = xspf.GetItems().First().Tags["foo"];
+            Assert.Equal(result,"testID");
         }
     }
 }


### PR DESCRIPTION
## Issue Information

**Link** - https://github.com/orgs/NPlaylist/projects/1#card-19369268
**Title** -BasePlaylist conversion

## Description

Implemented common conversion for all playlists.

## Sanity Check

- [x] Update the change log above
- [x] Add at least two reviewers to the PR
- [ ] Implement new unit tests
- [x] Full run of solution unit tests

## Question
We think, that we should do conversion one place. Conversion logic was moved in BasePlaylist and BasePlaylistItem classes, because it looks the same.