### PR TITLE
M3u should work with both types of newlines now

### DIFF
--- a/src/NPlaylist/M3u/M3uDeserializer.cs
+++ b/src/NPlaylist/M3u/M3uDeserializer.cs
@@ -12,6 +12,8 @@ namespace NPlaylist.M3u
         private const string decimalPattern = @"\d+(?:\.\d+)?";
         private const string titlePattern = @"(?:,(.+))";
         private const string pathPattern = ".+";
+        private const string newlinePattern = @"\r?\n";
+
         /*
          * Groups:
          *  1. Decimal duration
@@ -19,7 +21,7 @@ namespace NPlaylist.M3u
          *  3. Path       
         */
         private static readonly Regex mediaGroupingRgx = new Regex(
-              $"^#EXTINF:({decimalPattern}){titlePattern}?\n"
+              $"^#EXTINF:({decimalPattern}){titlePattern}?{newlinePattern}"
             + $"({pathPattern})");
 
         public M3uPlaylist Deserialize(string input)
@@ -61,7 +63,7 @@ namespace NPlaylist.M3u
         */
         private IEnumerable<M3uItem> ExtractItems(string input)
         {
-            const string twoLinesPattern = ".*\n.*\n";
+            var twoLinesPattern = $".*{newlinePattern}.*{newlinePattern}";
             foreach (var match in Regex.Matches(StringUtils.RemoveTheFirstLine(input), twoLinesPattern))
             {
                 yield return DeserializeMedia(match.ToString());
@@ -86,7 +88,7 @@ namespace NPlaylist.M3u
 
         private bool InputStartsWithM3uHeader(string input)
         {
-            return Regex.IsMatch(input, "^#EXTM3U8?(\n|$)");
+            return Regex.IsMatch(input, $"^#EXTM3U8?({newlinePattern}|$)");
         }
 
         private M3uItem DeserializeMedia(string mediaStr)
@@ -112,7 +114,7 @@ namespace NPlaylist.M3u
             const int headerNbOfLines = 1;
             const int mediaNbOfLines = 2;
 
-            var actualNbofLines = Regex.Matches(input, "\n").Count;
+            var actualNbofLines = Regex.Matches(input, newlinePattern).Count;
             var expectedNbOfLines = headerNbOfLines + (nbOfMediaItems * mediaNbOfLines);
 
             return expectedNbOfLines == actualNbofLines;

--- a/src/NPlaylist/M3u/M3uItem.cs
+++ b/src/NPlaylist/M3u/M3uItem.cs
@@ -4,9 +4,7 @@ namespace NPlaylist.M3u
 {
     public class M3uItem : BasePlaylistItem
     {
-        private const decimal defaultDuration = 0;
-
-        public M3uItem(string path, decimal duration) : base(path)
+        public M3uItem(string path, decimal duration = 0) : base(path)
         {
             Duration = duration;
         }
@@ -21,10 +19,10 @@ namespace NPlaylist.M3u
             {
                 if (!Tags.TryGetValue(TagNames.Length, out var valueStr))
                 {
-                    return defaultDuration;
+                    return 0;
                 }
 
-                return decimal.TryParse(valueStr, out var decimalValue) ? decimalValue : defaultDuration;
+                return decimal.TryParse(valueStr, out var decimalValue) ? decimalValue : 0;
             }
 
             set => Tags[TagNames.Length] = value.ToString(CultureInfo.InvariantCulture);

--- a/src/NPlaylist/M3u/M3uSerializer.cs
+++ b/src/NPlaylist/M3u/M3uSerializer.cs
@@ -7,7 +7,12 @@ namespace NPlaylist.M3u
 {
     public class M3uSerializer : IPlaylistSerializer<M3uPlaylist>
     {
-        private const string newline = "\n";
+        private readonly string _newLine;
+        
+        public M3uSerializer(string newline = null)
+        {
+            this._newLine = (newline == null) ? Environment.NewLine : newline;
+        }
 
         public string Serialize(M3uPlaylist playlist)
         {
@@ -26,8 +31,8 @@ namespace NPlaylist.M3u
         private void AddHeader(StringBuilder sb)
         {
             sb.Append("#EXTM3U");
-            sb.Append(newline);
-            sb.Append(newline);
+            sb.Append(_newLine);
+            sb.Append(_newLine);
         }
 
         private void AddMediaItems(StringBuilder sb, IEnumerable<M3uItem> mediaItems)
@@ -35,7 +40,7 @@ namespace NPlaylist.M3u
             foreach (var item in mediaItems)
             {
                 AddMedia(sb, item);
-                sb.Append(newline);
+                sb.Append(_newLine);
             }
         }
 
@@ -61,13 +66,13 @@ namespace NPlaylist.M3u
             sb.Append(formatedDuration);
             sb.Append(formatedTitle);
 
-            sb.Append(newline);
+            sb.Append(_newLine);
         }
 
         private void AddMediaBody(StringBuilder sb, M3uItem item)
         {
             sb.Append(item.Path);
-            sb.Append(newline);
+            sb.Append(_newLine);
         }
     }
 }

--- a/tests/NPlaylist.Tests/M3u/M3uDeserializerTests.cs
+++ b/tests/NPlaylist.Tests/M3u/M3uDeserializerTests.cs
@@ -47,6 +47,20 @@ namespace NPlaylist.Tests.M3u
             Assert.Throws<MediaFormatException>(() => deserializer.Deserialize(str));
         }
 
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public void Deserialize_DifferentTypesOfNewLines_ParseAsExpected(string newLine)
+        {
+            var str =
+                  "#EXTM3U" + newLine
+                + "#EXTINF:42.42" + newLine
+                + "foo.bar" + newLine;
+
+            var output = deserializer.Deserialize(str);
+            Assert.NotEmpty(output.Items);
+        }
+
         [Fact]
         public void Deserialize_MediaWithNoPath_ThrowsException()
         {

--- a/tests/NPlaylist.Tests/M3u/M3uSerializerTests.cs
+++ b/tests/NPlaylist.Tests/M3u/M3uSerializerTests.cs
@@ -6,6 +6,8 @@ namespace NPlaylist.Tests.M3u
 {
     public class M3uSerializerTests
     {
+        private const string newlinePattern = @"\r?\n";
+
         private readonly M3uSerializer serializer;
 
         public M3uSerializerTests()
@@ -35,8 +37,8 @@ namespace NPlaylist.Tests.M3u
             var output = serializer.Serialize(playlist);
 
             var pattern =
-                  @"#EXTINF:42.42\n"
-                + @"foo\n";
+                  @"#EXTINF:42.42" + newlinePattern
+                + @"foo" + newlinePattern;
 
             Assert.Matches(pattern, output);
         }
@@ -52,7 +54,7 @@ namespace NPlaylist.Tests.M3u
 
             var output = serializer.Serialize(playlist);
 
-            var pattern = @"#EXTINF:0\n";
+            var pattern = @"#EXTINF:0" + newlinePattern;
             Assert.Matches(pattern, output);
         }
 
@@ -67,7 +69,7 @@ namespace NPlaylist.Tests.M3u
 
             var output = serializer.Serialize(playlist);
 
-            var pattern = @"#EXTINF:0, Foo\n";
+            var pattern = @"#EXTINF:0, Foo" + newlinePattern;
             Assert.Matches(pattern, output);
         }
     }


### PR DESCRIPTION
Also, the M3uItem doesn't require a duration now

## Issue Information

**Link** - https://github.com/orgs/NPlaylist/projects/1#card-19692722
**Title** - Format exception from windows newlines

## Description

1. Made the serializer and deserializer able to work with both types of newline: "\r\n" and "\n"

## Sanity Check

- [x] Update the change log above
- [x] Add at least two reviewers to the PR
- [x] Implement new unit tests
- [x] Full run of solution unit tests